### PR TITLE
Refactor register handling, remove caching and fix bit masks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - refactor register definitions using namespaces and `constexpr`.
+- introduce `LTR390RT` root namespace for all register and bitfield definitions.
 - remove internal cached state (`_gain`, `_rate`, `_resolution`) and rely on register reads.
 - improve readability and maintainability by replacing magic numbers with named constants.
+- explicit float literals to avoid implicit conversions.
 
 ### Fixed
 - fix incorrect bit masking in `setRate()` that could overwrite resolution bits.
@@ -22,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking Changes
 - remove internal cached state. All configuration getters now read directly from hardware registers.
+- register and constant definitions are now under the `LTR390RT` namespace.
 
 ## [0.1.4] - 2026-03-31
 - fix #4, add specific status functions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.2.0] - 2026-04-08
+
+### Added
+- add `[[nodiscard]]` to critical getters to enforce return value usage.
+
+### Changed
+- refactor register definitions using namespaces and `constexpr`.
+- remove internal cached state (`_gain`, `_rate`, `_resolution`) and rely on register reads.
+- improve readability and maintainability by replacing magic numbers with named constants.
+
+### Fixed
+- fix incorrect bit masking in `setRate()` that could overwrite resolution bits.
+- fix incorrect bit mask handling in `setGain()`.
+- fix type error in `getUVIndex()` causing precision loss.
+
+### Breaking Changes
+- remove internal cached state. All configuration getters now read directly from hardware registers.
 
 ## [0.1.4] - 2026-03-31
 - fix #4, add specific status functions.

--- a/LTR390.h
+++ b/LTR390.h
@@ -64,10 +64,7 @@ class LTR390
 public:
   explicit LTR390(TwoWire *wire = &Wire):
     _wire{wire},
-    _address{LTR390_I2C::ADDRESS},
-    _resolution{2},
-    _rate{2},
-    _gain{1}
+    _address{LTR390_I2C::ADDRESS}
   {}
 
   bool begin()
@@ -135,7 +132,7 @@ public:
   {
     if (resolution > 5)
       resolution = 5;
-    _resolution = resolution;
+
     uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_MEAS_RATE);
     reg &= 0x07;
     reg |= (resolution << 4);
@@ -151,7 +148,7 @@ public:
   float getIntegrationTime() const
   {
     static constexpr uint16_t intTime[6] = {800, 400, 200, 100, 50, 25};
-    return intTime[_resolution] * 0.5f;
+    return intTime[getResolution()] * 0.5f;
   }
 
   //////////////////////////////////////////////
@@ -160,7 +157,7 @@ public:
   {
     if (rate > 7)
       rate = 7;
-    _rate = rate;
+    
     uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_MEAS_RATE);
     reg &= 0xF8;
     reg |= rate;
@@ -176,7 +173,7 @@ public:
   float getMeasurementTime() const
   {
     static constexpr uint16_t measTime[8] = {25, 50, 100, 200, 500, 1000, 2000, 2000};
-    return measTime[_rate];
+    return measTime[getRate()];
   }
 
   //////////////////////////////////////////////
@@ -185,7 +182,7 @@ public:
   {
     if (gain > 4)
       gain = 4;
-    _gain = gain;
+    
     uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_GAIN);
     reg &= 0xF8;
     reg |= gain;
@@ -202,7 +199,7 @@ public:
   uint8_t getGainFactor() const
   {
     static constexpr uint8_t gainFactor[5] = {1, 3, 6, 9, 18};
-    return gainFactor[_gain];
+    return gainFactor[getGain()];
   }
 
   //////////////////////////////////////////////
@@ -403,10 +400,6 @@ public:
 private:
   TwoWire *_wire;
   uint8_t _address;
-
-  uint8_t _resolution;
-  uint8_t _rate;
-  uint8_t _gain;
 };
 
 //  -- END OF FILE --

--- a/LTR390.h
+++ b/LTR390.h
@@ -71,9 +71,9 @@ namespace LTR390RT
   namespace STATUS
   {
     constexpr uint8_t POWER_ON  = 1 << 5; // 0x20
-    constexpr uint8_t INTERRUPT = 1 << 4; // 0x10
+    constexpr uint8_t INTERRUPT_BIT = 1 << 4; // 0x10
     constexpr uint8_t DATA_RDY  = 1 << 3; // 0x08
-    constexpr uint8_t MASK = POWER_ON | INTERRUPT | DATA_RDY;
+    constexpr uint8_t MASK = POWER_ON | INTERRUPT_BIT | DATA_RDY;
   }
 
   namespace PART_ID
@@ -272,7 +272,7 @@ public:
   [[nodiscard]] bool getInterruptStatus() const
   {
     uint8_t reg = readRegister(LTR390RT::REGISTER::MAIN_STATUS);
-    return (reg & LTR390RT::STATUS::INTERRUPT) > 0;
+    return (reg & LTR390RT::STATUS::INTERRUPT_BIT) > 0;
   }
 
   [[nodiscard]] bool getDataStatus() const

--- a/LTR390.h
+++ b/LTR390.h
@@ -15,55 +15,84 @@
 //  LTR390 ERROR CODES
 //  TODO
 
-//  LTR390 REGISTERS (page 13 datasheet)
-namespace LTR390RT_REGISTER
+namespace LTR390RT
 {
-  constexpr uint8_t LTR390_MAIN_CTRL             = 0x00;
-  constexpr uint8_t LTR390_ALS_UVS_MEAS_RATE     = 0x04;
-  constexpr uint8_t LTR390_ALS_UVS_GAIN          = 0x05;
-  constexpr uint8_t LTR390_PART_ID               = 0x06;
-  constexpr uint8_t LTR390_MAIN_STATUS           = 0x07;
+  //  LTR390 REGISTERS (page 13 datasheet)
+  namespace REGISTER
+  {
+    constexpr uint8_t MAIN_CTRL          = 0x00;
+    constexpr uint8_t ALS_UVS_MEAS_RATE  = 0x04;
+    constexpr uint8_t ALS_UVS_GAIN  = 0x05;
+    constexpr uint8_t PART_ID       = 0x06;
+    constexpr uint8_t MAIN_STATUS   = 0x07;
 
-  constexpr uint8_t LTR390_ALS_DATA_0            = 0x0D;
-  constexpr uint8_t LTR390_ALS_DATA_1            = 0x0E;
-  constexpr uint8_t LTR390_ALS_DATA_2            = 0x0F;
+    constexpr uint8_t ALS_DATA_0 = 0x0D;
+    constexpr uint8_t ALS_DATA_1 = 0x0E;
+    constexpr uint8_t ALS_DATA_2 = 0x0F;
 
-  constexpr uint8_t LTR390_UVS_DATA_0            = 0x10;
-  constexpr uint8_t LTR390_UVS_DATA_1            = 0x11;
-  constexpr uint8_t LTR390_UVS_DATA_2            = 0x12;
+    constexpr uint8_t UVS_DATA_0 = 0x10;
+    constexpr uint8_t UVS_DATA_1 = 0x11;
+    constexpr uint8_t UVS_DATA_2 = 0x12;
 
-  constexpr uint8_t LTR390_INT_CFG               = 0x19;
-  constexpr uint8_t LTR390_INT_PST               = 0x1A;
+    constexpr uint8_t INT_CFG  = 0x19;
+    constexpr uint8_t INT_PST  = 0x1A;
 
-  constexpr uint8_t LTR390_ALS_UVS_THRES_UP_0    = 0x21;
-  constexpr uint8_t LTR390_ALS_UVS_THRES_UP_1    = 0x22;
-  constexpr uint8_t LTR390_ALS_UVS_THRES_UP_2    = 0x23;
+    constexpr uint8_t ALS_UVS_THRES_UP_0 = 0x21;
+    constexpr uint8_t ALS_UVS_THRES_UP_1 = 0x22;
+    constexpr uint8_t ALS_UVS_THRES_UP_2 = 0x23;
 
-  constexpr uint8_t LTR390_ALS_UVS_THRES_LOW_0   = 0x24;
-  constexpr uint8_t LTR390_ALS_UVS_THRES_LOW_1   = 0x25;
-  constexpr uint8_t LTR390_ALS_UVS_THRES_LOW_2   = 0x26;
-}
+    constexpr uint8_t ALS_UVS_THRES_LOW_0 = 0x24;
+    constexpr uint8_t ALS_UVS_THRES_LOW_1 = 0x25;
+    constexpr uint8_t ALS_UVS_THRES_LOW_2 = 0x26;
+  }
 
-namespace LTR390_MAIN_CTRL
-{
-  constexpr uint8_t ENABLE   = 0x02; // Bit 1: ALS/UVS Enable
-  constexpr uint8_t UVS_MODE = 0x08; // Bit 3: 1 = UV, 0 = ALS
-  constexpr uint8_t SW_RESET = 0x10; // Bit 4: Software reset
+  namespace MAIN_CTRL
+  {
+    constexpr uint8_t ENABLE   = 0x02; // Bit 1: ALS/UVS Enable
+    constexpr uint8_t UVS_MODE = 0x08; // Bit 3: 1 = UV, 0 = ALS
+    constexpr uint8_t SW_RESET = 0x10; // Bit 4: Software reset
 
-  constexpr uint8_t ALS_ACTIVE = ENABLE;                 // ALS mode (UVS_MODE = 0)
-  constexpr uint8_t UVS_ACTIVE = ENABLE | UVS_MODE;      // UV mode
-}
+    constexpr uint8_t ALS_ACTIVE = ENABLE;            // ALS mode (UVS_MODE = 0)
+    constexpr uint8_t UVS_ACTIVE = ENABLE | UVS_MODE; // UV mode
+  }
 
-namespace LTR390_I2C
-{
-  constexpr uint8_t ADDRESS = 0x53;
-}
+  namespace I2C
+  {
+    constexpr uint8_t ADDRESS = 0x53;
+  }
 
-namespace LTR390_MEAS_RATE
-{
-  constexpr uint8_t RATE_MASK   = 0x07; // bits 0-2
-  constexpr uint8_t RES_MASK    = 0x70; // bits 4-6
-  constexpr uint8_t RES_SHIFT   = 4;
+  namespace MEAS_RATE
+  {
+    constexpr uint8_t RATE_MASK = 0x07; // bits 0-2
+    constexpr uint8_t RES_MASK  = 0x70; // bits 4-6
+    constexpr uint8_t RES_SHIFT = 4;
+  }
+
+  namespace STATUS
+  {
+    constexpr uint8_t POWER_ON  = 1 << 5; // 0x20
+    constexpr uint8_t INTERRUPT = 1 << 4; // 0x10
+    constexpr uint8_t DATA_RDY  = 1 << 3; // 0x08
+    constexpr uint8_t MASK = POWER_ON | INTERRUPT | DATA_RDY;
+  }
+
+  namespace PART_ID
+  {
+    constexpr uint8_t MASK     = 0xF0; // bits 7:4
+    constexpr uint8_t REV_MASK = 0x0F; // bits 3:0
+    constexpr uint8_t SHIFT    = 4;
+  }
+
+  namespace DATA
+  {
+    constexpr uint8_t ADC_DATA_MASK = 0x0F; // bits 3:0 valid data
+  }
+
+  namespace THRESHOLD
+  {
+    constexpr uint8_t MSB_MASK  = 0x0F; // upper/lower threshold high byte
+    constexpr uint8_t FULL_MASK = 0xFF; // full 8-bit mask
+  }
 }
 
 class LTR390
@@ -71,7 +100,7 @@ class LTR390
 public:
   explicit LTR390(TwoWire *wire = &Wire):
     _wire{wire},
-    _address{LTR390_I2C::ADDRESS}
+    _address{LTR390RT::I2C::ADDRESS}
   {}
 
   bool begin()
@@ -96,39 +125,39 @@ public:
   //
   void setALSMode()
   {
-    writeRegister(LTR390RT_REGISTER::LTR390_MAIN_CTRL, LTR390_MAIN_CTRL::ALS_ACTIVE);
+    writeRegister(LTR390RT::REGISTER::MAIN_CTRL, LTR390RT::MAIN_CTRL::ALS_ACTIVE);
   }
 
   void setUVSMode()
   {
-    writeRegister(LTR390RT_REGISTER::LTR390_MAIN_CTRL, LTR390_MAIN_CTRL::UVS_ACTIVE);
+    writeRegister(LTR390RT::REGISTER::MAIN_CTRL, LTR390RT::MAIN_CTRL::UVS_ACTIVE);
   }
 
   uint8_t reset()
   {
-    writeRegister(LTR390RT_REGISTER::LTR390_MAIN_CTRL, LTR390_MAIN_CTRL::SW_RESET);
+    writeRegister(LTR390RT::REGISTER::MAIN_CTRL, LTR390RT::MAIN_CTRL::SW_RESET);
     delay(100);
-    return readRegister(LTR390RT_REGISTER::LTR390_MAIN_CTRL);
+    return readRegister(LTR390RT::REGISTER::MAIN_CTRL);
   }
 
   void enable()
   {
-    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_MAIN_CTRL);
-    reg |= LTR390_MAIN_CTRL::ENABLE;
-    writeRegister(LTR390RT_REGISTER::LTR390_MAIN_CTRL, reg);
+    uint8_t reg = readRegister(LTR390RT::REGISTER::MAIN_CTRL);
+    reg |= LTR390RT::MAIN_CTRL::ENABLE;
+    writeRegister(LTR390RT::REGISTER::MAIN_CTRL, reg);
   }
 
   void disable()
   {
-    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_MAIN_CTRL);
-    reg &= ~LTR390_MAIN_CTRL::ENABLE;
-    writeRegister(LTR390RT_REGISTER::LTR390_MAIN_CTRL, reg);
+    uint8_t reg = readRegister(LTR390RT::REGISTER::MAIN_CTRL);
+    reg &= ~LTR390RT::MAIN_CTRL::ENABLE;
+    writeRegister(LTR390RT::REGISTER::MAIN_CTRL, reg);
   }
 
   [[nodiscard]] bool isEnabled() const
   {
-    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_MAIN_CTRL);
-    return (reg & LTR390_MAIN_CTRL::ENABLE) > 0;
+    uint8_t reg = readRegister(LTR390RT::REGISTER::MAIN_CTRL);
+    return (reg & LTR390RT::MAIN_CTRL::ENABLE) > 0;
   }
 
   //////////////////////////////////////////////
@@ -140,16 +169,16 @@ public:
     if (resolution > 5)
       resolution = 5;
 
-    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_MEAS_RATE);
-    reg &= LTR390_MEAS_RATE::RATE_MASK;
-    reg |= (resolution << LTR390_MEAS_RATE::RES_SHIFT);
-    writeRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_MEAS_RATE, reg);
+    uint8_t reg = readRegister(LTR390RT::REGISTER::ALS_UVS_MEAS_RATE);
+    reg &= LTR390RT::MEAS_RATE::RATE_MASK;
+    reg |= (resolution << LTR390RT::MEAS_RATE::RES_SHIFT);
+    writeRegister(LTR390RT::REGISTER::ALS_UVS_MEAS_RATE, reg);
   }
 
   [[nodiscard]] uint8_t getResolution() const
   {
-    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_MEAS_RATE);
-    return (reg >> LTR390_MEAS_RATE::RES_SHIFT) & LTR390_MEAS_RATE::RATE_MASK;
+    uint8_t reg = readRegister(LTR390RT::REGISTER::ALS_UVS_MEAS_RATE);
+    return (reg >> LTR390RT::MEAS_RATE::RES_SHIFT) & LTR390RT::MEAS_RATE::RATE_MASK;
   }
 
   [[nodiscard]] float getIntegrationTime() const
@@ -165,16 +194,16 @@ public:
     if (rate > 7)
       rate = 7;
     
-    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_MEAS_RATE);
-    reg &= ~LTR390_MEAS_RATE::RES_MASK;
+    uint8_t reg = readRegister(LTR390RT::REGISTER::ALS_UVS_MEAS_RATE);
+    reg &= ~LTR390RT::MEAS_RATE::RES_MASK;
     reg |= rate;
-    writeRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_MEAS_RATE, reg);
+    writeRegister(LTR390RT::REGISTER::ALS_UVS_MEAS_RATE, reg);
   }
 
   [[nodiscard]] uint8_t getRate() const
   {
-    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_MEAS_RATE);
-    return reg & LTR390_MEAS_RATE::RATE_MASK;
+    uint8_t reg = readRegister(LTR390RT::REGISTER::ALS_UVS_MEAS_RATE);
+    return reg & LTR390RT::MEAS_RATE::RATE_MASK;
   }
 
   [[nodiscard]] float getMeasurementTime() const
@@ -190,17 +219,16 @@ public:
     if (gain > 4)
       gain = 4;
     
-    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_GAIN);
-    reg &= ~LTR390_MEAS_RATE::RATE_MASK;
+    uint8_t reg = readRegister(LTR390RT::REGISTER::ALS_UVS_GAIN);
+    reg &= ~LTR390RT::MEAS_RATE::RATE_MASK;
     reg |= gain;
-    writeRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_GAIN, reg);
+    writeRegister(LTR390RT::REGISTER::ALS_UVS_GAIN, reg);
   }
 
   [[nodiscard]] uint8_t getGain() const
   {
-    //  return _gain; // from cache
-    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_GAIN);
-    return reg & LTR390_MEAS_RATE::RATE_MASK;
+    uint8_t reg = readRegister(LTR390RT::REGISTER::ALS_UVS_GAIN);
+    return reg & LTR390RT::MEAS_RATE::RATE_MASK;
   }
 
   [[nodiscard]] uint8_t getGainFactor() const
@@ -215,14 +243,14 @@ public:
   //
   [[nodiscard]] uint8_t getPartID() const
   {
-    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_PART_ID);
-    return reg >> 4;
+    uint8_t reg = readRegister(LTR390RT::REGISTER::PART_ID);
+    return (reg & LTR390RT::PART_ID::MASK) >> LTR390RT::PART_ID::SHIFT;
   }
 
   [[nodiscard]] uint8_t getRevisionID() const
   {
-    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_PART_ID);
-    return reg & 0x0F;
+    uint8_t reg = readRegister(LTR390RT::REGISTER::PART_ID);
+    return reg & LTR390RT::PART_ID::REV_MASK;
   }
 
   //////////////////////////////////////////////
@@ -231,26 +259,26 @@ public:
   //
   [[nodiscard]] uint8_t getStatus() const
   {
-    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_MAIN_STATUS);
-    return reg & 0x38;
+    uint8_t reg = readRegister(LTR390RT::REGISTER::MAIN_STATUS);
+    return reg & LTR390RT::STATUS::MASK;
   }
 
   [[nodiscard]] bool getPowerOnStatus() const
   {
-    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_MAIN_STATUS);
-    return (reg & 0x20) > 0;
+    uint8_t reg = readRegister(LTR390RT::REGISTER::MAIN_STATUS);
+    return (reg & LTR390RT::STATUS::POWER_ON) > 0;
   }
 
   [[nodiscard]] bool getInterruptStatus() const
   {
-    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_MAIN_STATUS);
-    return (reg & 0x10) > 0;
+    uint8_t reg = readRegister(LTR390RT::REGISTER::MAIN_STATUS);
+    return (reg & LTR390RT::STATUS::INTERRUPT) > 0;
   }
 
   [[nodiscard]] bool getDataStatus() const
   {
-    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_MAIN_STATUS);
-    return (reg & 0x08) > 0;
+    uint8_t reg = readRegister(LTR390RT::REGISTER::MAIN_STATUS);
+    return (reg & LTR390RT::STATUS::DATA_RDY) > 0;
   }
 
   //////////////////////////////////////////////
@@ -259,33 +287,33 @@ public:
   //
   [[nodiscard]] uint32_t getALSData() const
   {
-    uint32_t value = readRegister(LTR390RT_REGISTER::LTR390_ALS_DATA_2) & 0x0F;
+    uint32_t value = readRegister(LTR390RT::REGISTER::ALS_DATA_2) & LTR390RT::DATA::ADC_DATA_MASK;
 
     value <<= 8;
-    value += readRegister(LTR390RT_REGISTER::LTR390_ALS_DATA_1);
+    value += readRegister(LTR390RT::REGISTER::ALS_DATA_1);
 
     value <<= 8;
-    value += readRegister(LTR390RT_REGISTER::LTR390_ALS_DATA_0);
+    value += readRegister(LTR390RT::REGISTER::ALS_DATA_0);
 
     return value;
   }
 
   [[nodiscard]] uint32_t getUVSData() const
   {
-    uint32_t value = readRegister(LTR390RT_REGISTER::LTR390_UVS_DATA_2) & 0x0F;
+    uint32_t value = readRegister(LTR390RT::REGISTER::UVS_DATA_2) & LTR390RT::DATA::ADC_DATA_MASK;
 
     value <<= 8;
-    value += readRegister(LTR390RT_REGISTER::LTR390_UVS_DATA_1);
+    value += readRegister(LTR390RT::REGISTER::UVS_DATA_1);
 
     value <<= 8;
-    value += readRegister(LTR390RT_REGISTER::LTR390_UVS_DATA_0);
+    value += readRegister(LTR390RT::REGISTER::UVS_DATA_0);
 
     return value;
   }
 
   [[nodiscard]] float getLUX(float windowsFactor = 1.0f) const
   {
-    float lux = (100 * 0.6f) * getALSData();
+    float lux = (100.0f * 0.6f) * getALSData();
     lux /= (getGainFactor() * getIntegrationTime());
 
     if (windowsFactor > 1.0f)
@@ -294,14 +322,14 @@ public:
     return lux;
   }
 
-  [[nodiscard]] float getUVIndex(float windowsFactor = 1.0) const
+  [[nodiscard]] float getUVIndex(float windowsFactor = 1.0f) const
   {
-    float reciprokeSensitivity = (18 * 400) / 2300.0f;
+    float reciprokeSensitivity = (18.0f * 400.0f) / 2300.0f;
     reciprokeSensitivity /= (getGainFactor() * getIntegrationTime());
     
     float uvi = getUVSData() * reciprokeSensitivity;
 
-    if (windowsFactor > 1.0)
+    if (windowsFactor > 1.0f)
       uvi *= windowsFactor;
 
     return uvi;
@@ -314,22 +342,22 @@ public:
   //
   [[nodiscard]] int setInterruptConfig(uint8_t value)
   {
-    return writeRegister(LTR390RT_REGISTER::LTR390_INT_CFG, value);
+    return writeRegister(LTR390RT::REGISTER::INT_CFG, value);
   }
 
   [[nodiscard]] uint8_t getInterruptConfig() const
   {
-    return readRegister(LTR390RT_REGISTER::LTR390_INT_CFG);
+    return readRegister(LTR390RT::REGISTER::INT_CFG);
   }
 
   int setInterruptPersist(uint8_t value)
   {
-    return writeRegister(LTR390RT_REGISTER::LTR390_INT_PST, value);
+    return writeRegister(LTR390RT::REGISTER::INT_PST, value);
   }
 
   [[nodiscard]] uint8_t getInterruptPersist() const
   {
-    return readRegister(LTR390RT_REGISTER::LTR390_INT_PST);
+    return readRegister(LTR390RT::REGISTER::INT_PST);
   }
 
   //////////////////////////////////////////////
@@ -339,42 +367,42 @@ public:
   //
   void setHighThreshold(uint32_t value)
   {
-    writeRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_UP_0, value & 0xFF);
+    writeRegister(LTR390RT::REGISTER::ALS_UVS_THRES_UP_0, value & LTR390RT::THRESHOLD::FULL_MASK);
     value >>= 8;    
-    writeRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_UP_1, value & 0xFF);
+    writeRegister(LTR390RT::REGISTER::ALS_UVS_THRES_UP_1, value & LTR390RT::THRESHOLD::FULL_MASK);
     value >>= 8;
-    writeRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_UP_2, value & 0x0F);
+    writeRegister(LTR390RT::REGISTER::ALS_UVS_THRES_UP_2, value & LTR390RT::THRESHOLD::MSB_MASK);
   }
 
   [[nodiscard]] uint32_t getHighThreshold() const
   {
-    uint32_t value = readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_UP_2) & 0x0F;
+    uint32_t value = readRegister(LTR390RT::REGISTER::ALS_UVS_THRES_UP_2) & LTR390RT::THRESHOLD::MSB_MASK;
 
     value <<= 8;
-    value += readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_UP_1);
+    value += readRegister(LTR390RT::REGISTER::ALS_UVS_THRES_UP_1);
     value <<= 8;
-    value += readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_UP_0);
+    value += readRegister(LTR390RT::REGISTER::ALS_UVS_THRES_UP_0);
 
     return value;
   }
 
   void setLowThreshold(uint32_t value)
   {
-    writeRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_LOW_0, value & 0xFF);
+    writeRegister(LTR390RT::REGISTER::ALS_UVS_THRES_LOW_0, value & LTR390RT::THRESHOLD::FULL_MASK);
     value >>= 8;
-    writeRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_LOW_1, value & 0xFF);
+    writeRegister(LTR390RT::REGISTER::ALS_UVS_THRES_LOW_1, value & LTR390RT::THRESHOLD::FULL_MASK);
     value >>= 8;
-    writeRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_LOW_2, value & 0x0F);
+    writeRegister(LTR390RT::REGISTER::ALS_UVS_THRES_LOW_2, value & LTR390RT::THRESHOLD::MSB_MASK);
   }
 
   [[nodiscard]] uint32_t getLowThreshold() const
   {
-    uint32_t value = readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_LOW_2) & 0x0F;
+    uint32_t value = readRegister(LTR390RT::REGISTER::ALS_UVS_THRES_LOW_2) & LTR390RT::THRESHOLD::MSB_MASK;
 
     value <<= 8;
-    value += readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_LOW_1);
+    value += readRegister(LTR390RT::REGISTER::ALS_UVS_THRES_LOW_1);
     value <<= 8;
-    value += readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_LOW_0);
+    value += readRegister(LTR390RT::REGISTER::ALS_UVS_THRES_LOW_0);
 
     return value;
   }

--- a/LTR390.h
+++ b/LTR390.h
@@ -59,6 +59,13 @@ namespace LTR390_I2C
   constexpr uint8_t ADDRESS = 0x53;
 }
 
+namespace LTR390_MEAS_RATE
+{
+  constexpr uint8_t RATE_MASK   = 0x07; // bits 0-2
+  constexpr uint8_t RES_MASK    = 0x70; // bits 4-6
+  constexpr uint8_t RES_SHIFT   = 4;
+}
+
 class LTR390
 {
 public:
@@ -118,7 +125,7 @@ public:
     writeRegister(LTR390RT_REGISTER::LTR390_MAIN_CTRL, reg);
   }
 
-  bool isEnabled() const
+  [[nodiscard]] bool isEnabled() const
   {
     uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_MAIN_CTRL);
     return (reg & LTR390_MAIN_CTRL::ENABLE) > 0;
@@ -134,20 +141,20 @@ public:
       resolution = 5;
 
     uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_MEAS_RATE);
-    reg &= 0x07;
-    reg |= (resolution << 4);
+    reg &= LTR390_MEAS_RATE::RATE_MASK;
+    reg |= (resolution << LTR390_MEAS_RATE::RES_SHIFT);
     writeRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_MEAS_RATE, reg);
   }
 
-  uint8_t getResolution() const
+  [[nodiscard]] uint8_t getResolution() const
   {
     uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_MEAS_RATE);
-    return (reg >> 4) & 0x07;
+    return (reg >> LTR390_MEAS_RATE::RES_SHIFT) & LTR390_MEAS_RATE::RATE_MASK;
   }
 
-  float getIntegrationTime() const
+  [[nodiscard]] float getIntegrationTime() const
   {
-    static constexpr uint16_t intTime[6] = {800, 400, 200, 100, 50, 25};
+    static const uint16_t intTime[6] = {800, 400, 200, 100, 50, 25};
     return intTime[getResolution()] * 0.5f;
   }
 
@@ -159,20 +166,20 @@ public:
       rate = 7;
     
     uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_MEAS_RATE);
-    reg &= 0xF8;
+    reg &= ~LTR390_MEAS_RATE::RES_MASK;
     reg |= rate;
     writeRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_MEAS_RATE, reg);
   }
 
-  uint8_t getRate() const
+  [[nodiscard]] uint8_t getRate() const
   {
     uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_MEAS_RATE);
-    return reg & 0x07;
+    return reg & LTR390_MEAS_RATE::RATE_MASK;
   }
 
-  float getMeasurementTime() const
+  [[nodiscard]] float getMeasurementTime() const
   {
-    static constexpr uint16_t measTime[8] = {25, 50, 100, 200, 500, 1000, 2000, 2000};
+    static const uint16_t measTime[8] = {25, 50, 100, 200, 500, 1000, 2000, 2000};
     return measTime[getRate()];
   }
 
@@ -184,21 +191,21 @@ public:
       gain = 4;
     
     uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_GAIN);
-    reg &= 0xF8;
+    reg &= ~LTR390_MEAS_RATE::RATE_MASK;
     reg |= gain;
     writeRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_GAIN, reg);
   }
 
-  uint8_t getGain() const
+  [[nodiscard]] uint8_t getGain() const
   {
     //  return _gain; // from cache
     uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_GAIN);
-    return reg & 0x07;
+    return reg & LTR390_MEAS_RATE::RATE_MASK;
   }
 
-  uint8_t getGainFactor() const
+  [[nodiscard]] uint8_t getGainFactor() const
   {
-    static constexpr uint8_t gainFactor[5] = {1, 3, 6, 9, 18};
+    static const uint8_t gainFactor[5] = {1, 3, 6, 9, 18};
     return gainFactor[getGain()];
   }
 
@@ -206,13 +213,13 @@ public:
   //
   //  PART_ID
   //
-  uint8_t getPartID() const
+  [[nodiscard]] uint8_t getPartID() const
   {
     uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_PART_ID);
     return reg >> 4;
   }
 
-  uint8_t getRevisionID() const
+  [[nodiscard]] uint8_t getRevisionID() const
   {
     uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_PART_ID);
     return reg & 0x0F;
@@ -222,25 +229,25 @@ public:
   //
   //  MAIN STATUS
   //
-  uint8_t getStatus() const
+  [[nodiscard]] uint8_t getStatus() const
   {
     uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_MAIN_STATUS);
     return reg & 0x38;
   }
 
-  bool getPowerOnStatus() const
+  [[nodiscard]] bool getPowerOnStatus() const
   {
     uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_MAIN_STATUS);
     return (reg & 0x20) > 0;
   }
 
-  bool getInterruptStatus() const
+  [[nodiscard]] bool getInterruptStatus() const
   {
     uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_MAIN_STATUS);
     return (reg & 0x10) > 0;
   }
 
-  bool getDataStatus() const
+  [[nodiscard]] bool getDataStatus() const
   {
     uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_MAIN_STATUS);
     return (reg & 0x08) > 0;
@@ -250,42 +257,53 @@ public:
   //
   //  GET DATA
   //
-  uint32_t getALSData() const
+  [[nodiscard]] uint32_t getALSData() const
   {
     uint32_t value = readRegister(LTR390RT_REGISTER::LTR390_ALS_DATA_2) & 0x0F;
+
     value <<= 8;
     value += readRegister(LTR390RT_REGISTER::LTR390_ALS_DATA_1);
+
     value <<= 8;
     value += readRegister(LTR390RT_REGISTER::LTR390_ALS_DATA_0);
+
     return value;
   }
 
-  uint32_t getUVSData() const
+  [[nodiscard]] uint32_t getUVSData() const
   {
     uint32_t value = readRegister(LTR390RT_REGISTER::LTR390_UVS_DATA_2) & 0x0F;
+
     value <<= 8;
     value += readRegister(LTR390RT_REGISTER::LTR390_UVS_DATA_1);
+
     value <<= 8;
     value += readRegister(LTR390RT_REGISTER::LTR390_UVS_DATA_0);
+
     return value;
   }
 
-  float getLUX(float windowsFactor = 1.0f) const
+  [[nodiscard]] float getLUX(float windowsFactor = 1.0f) const
   {
     float lux = (100 * 0.6f) * getALSData();
     lux /= (getGainFactor() * getIntegrationTime());
+
     if (windowsFactor > 1.0f)
       lux *= windowsFactor;
+
     return lux;
   }
 
-  float getUVIndex(float windowsFactor = 1.0) const
+  [[nodiscard]] float getUVIndex(float windowsFactor = 1.0) const
   {
     float reciprokeSensitivity = (18 * 400) / 2300.0f;
     reciprokeSensitivity /= (getGainFactor() * getIntegrationTime());
-    uint32_t uvi = getUVSData() * reciprokeSensitivity;
+    
+    float uvi = getUVSData() * reciprokeSensitivity;
+
     if (windowsFactor > 1.0)
       uvi *= windowsFactor;
+
     return uvi;
   }
 
@@ -294,12 +312,12 @@ public:
   //  INTERRUPT
   //  TODO elaborate
   //
-  int setInterruptConfig(uint8_t value)
+  [[nodiscard]] int setInterruptConfig(uint8_t value)
   {
     return writeRegister(LTR390RT_REGISTER::LTR390_INT_CFG, value);
   }
 
-  uint8_t getInterruptConfig() const
+  [[nodiscard]] uint8_t getInterruptConfig() const
   {
     return readRegister(LTR390RT_REGISTER::LTR390_INT_CFG);
   }
@@ -309,7 +327,7 @@ public:
     return writeRegister(LTR390RT_REGISTER::LTR390_INT_PST, value);
   }
 
-  uint8_t getInterruptPersist() const
+  [[nodiscard]] uint8_t getInterruptPersist() const
   {
     return readRegister(LTR390RT_REGISTER::LTR390_INT_PST);
   }
@@ -322,19 +340,21 @@ public:
   void setHighThreshold(uint32_t value)
   {
     writeRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_UP_0, value & 0xFF);
-    value >>= 8;
+    value >>= 8;    
     writeRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_UP_1, value & 0xFF);
     value >>= 8;
     writeRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_UP_2, value & 0x0F);
   }
 
-  uint32_t getHighThreshold() const
+  [[nodiscard]] uint32_t getHighThreshold() const
   {
     uint32_t value = readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_UP_2) & 0x0F;
+
     value <<= 8;
     value += readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_UP_1);
     value <<= 8;
     value += readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_UP_0);
+
     return value;
   }
 
@@ -347,13 +367,15 @@ public:
     writeRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_LOW_2, value & 0x0F);
   }
 
-  uint32_t getLowThreshold() const
+  [[nodiscard]] uint32_t getLowThreshold() const
   {
     uint32_t value = readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_LOW_2) & 0x0F;
+
     value <<= 8;
     value += readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_LOW_1);
     value <<= 8;
     value += readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_LOW_0);
+
     return value;
   }
 
@@ -375,7 +397,7 @@ public:
     return n;
   }
 
-  uint8_t readRegister(uint8_t reg) const
+  uint8_t readRegister(uint8_t reg)
   {
     _wire->beginTransmission(_address);
     _wire->write(reg);

--- a/LTR390.h
+++ b/LTR390.h
@@ -3,20 +3,17 @@
 //    FILE: LTR390.h
 //  AUTHOR: Rob Tillaart
 //    DATE: 2024-04-29
-// VERSION: 0.1.4
+// VERSION: 0.2.0
 // PURPOSE: Arduino library for the I2C LTR390 UV sensor.
 //     URL: https://github.com/RobTillaart/LTR390_RT
-
 
 #include "Arduino.h"
 #include "Wire.h"
 
-
-#define LTR390_LIB_VERSION         (F("0.1.4"))
+#define LTR390_LIB_VERSION (F("0.2.0"))
 
 //  LTR390 ERROR CODES
 //  TODO
-
 
 //  LTR390 REGISTERS (page 13 datasheet)
 namespace LTR390RT_REGISTER

--- a/LTR390.h
+++ b/LTR390.h
@@ -19,59 +19,75 @@
 
 
 //  LTR390 REGISTERS (page 13 datasheet)
-#define LTR390_MAIN_CTRL              0x00
-#define LTR390_ALS_UVS_MEAS_RATE      0x04
-#define LTR390_ALS_UVS_GAIN           0x05
-#define LTR390_PART_ID                0x06
-#define LTR390_MAIN_STATUS            0x07
+namespace LTR390RT_REGISTER
+{
+  constexpr uint8_t LTR390_MAIN_CTRL             = 0x00;
+  constexpr uint8_t LTR390_ALS_UVS_MEAS_RATE     = 0x04;
+  constexpr uint8_t LTR390_ALS_UVS_GAIN          = 0x05;
+  constexpr uint8_t LTR390_PART_ID               = 0x06;
+  constexpr uint8_t LTR390_MAIN_STATUS           = 0x07;
 
-#define LTR390_ALS_DATA_0             0x0D
-#define LTR390_ALS_DATA_1             0x0E
-#define LTR390_ALS_DATA_2             0x0F
+  constexpr uint8_t LTR390_ALS_DATA_0            = 0x0D;
+  constexpr uint8_t LTR390_ALS_DATA_1            = 0x0E;
+  constexpr uint8_t LTR390_ALS_DATA_2            = 0x0F;
 
-#define LTR390_UVS_DATA_0             0x10
-#define LTR390_UVS_DATA_1             0x11
-#define LTR390_UVS_DATA_2             0x12
+  constexpr uint8_t LTR390_UVS_DATA_0            = 0x10;
+  constexpr uint8_t LTR390_UVS_DATA_1            = 0x11;
+  constexpr uint8_t LTR390_UVS_DATA_2            = 0x12;
 
-#define LTR390_INT_CFG                0x19
-#define LTR390_INT_PST                0x1A
+  constexpr uint8_t LTR390_INT_CFG               = 0x19;
+  constexpr uint8_t LTR390_INT_PST               = 0x1A;
 
-#define LTR390_ALS_UVS_THRES_UP_0     0x21
-#define LTR390_ALS_UVS_THRES_UP_1     0x22
-#define LTR390_ALS_UVS_THRES_UP_2     0x23
-#define LTR390_ALS_UVS_THRES_LOW_0    0x24
-#define LTR390_ALS_UVS_THRES_LOW_1    0x25
-#define LTR390_ALS_UVS_THRES_LOW_2    0x26
+  constexpr uint8_t LTR390_ALS_UVS_THRES_UP_0    = 0x21;
+  constexpr uint8_t LTR390_ALS_UVS_THRES_UP_1    = 0x22;
+  constexpr uint8_t LTR390_ALS_UVS_THRES_UP_2    = 0x23;
 
+  constexpr uint8_t LTR390_ALS_UVS_THRES_LOW_0   = 0x24;
+  constexpr uint8_t LTR390_ALS_UVS_THRES_LOW_1   = 0x25;
+  constexpr uint8_t LTR390_ALS_UVS_THRES_LOW_2   = 0x26;
+}
+
+namespace LTR390_MAIN_CTRL
+{
+  constexpr uint8_t ENABLE   = 0x02; // Bit 1: ALS/UVS Enable
+  constexpr uint8_t UVS_MODE = 0x08; // Bit 3: 1 = UV, 0 = ALS
+  constexpr uint8_t SW_RESET = 0x10; // Bit 4: Software reset
+
+  constexpr uint8_t ALS_ACTIVE = ENABLE;                 // ALS mode (UVS_MODE = 0)
+  constexpr uint8_t UVS_ACTIVE = ENABLE | UVS_MODE;      // UV mode
+}
+
+namespace LTR390_I2C
+{
+  constexpr uint8_t ADDRESS = 0x53;
+}
 
 class LTR390
 {
 public:
-  LTR390(TwoWire *wire = &Wire)
-  {
-    _address = 0x53;  //  LTR390 device itself
-    _wire = wire;
-    _gain = 1;
-    _resolution = 2;
-    _rate = 2;
-  }
+  explicit LTR390(TwoWire *wire = &Wire):
+    _wire{wire},
+    _address{LTR390_I2C::ADDRESS},
+    _resolution{2},
+    _rate{2},
+    _gain{1}
+  {}
 
   bool begin()
   {
     return isConnected();
   }
 
-  bool isConnected()
+  bool isConnected() const
   {
     _wire->beginTransmission(_address);
     return (_wire->endTransmission() == 0);
   }
 
-  uint8_t getAddress()
+  uint8_t getAddress() const
   {
     return _address;
   }
-
 
   //////////////////////////////////////////////
   //
@@ -79,202 +95,203 @@ public:
   //
   void setALSMode()
   {
-    writeRegister(LTR390_MAIN_CTRL, 0x02);
+    writeRegister(LTR390RT_REGISTER::LTR390_MAIN_CTRL, LTR390_MAIN_CTRL::ALS_ACTIVE);
   }
 
   void setUVSMode()
   {
-    writeRegister(LTR390_MAIN_CTRL, 0x0A);
+    writeRegister(LTR390RT_REGISTER::LTR390_MAIN_CTRL, LTR390_MAIN_CTRL::UVS_ACTIVE);
   }
 
   uint8_t reset()
   {
-    writeRegister(LTR390_MAIN_CTRL, 0x10);
+    writeRegister(LTR390RT_REGISTER::LTR390_MAIN_CTRL, LTR390_MAIN_CTRL::SW_RESET);
     delay(100);
-    return readRegister(LTR390_MAIN_CTRL);
+    return readRegister(LTR390RT_REGISTER::LTR390_MAIN_CTRL);
   }
 
   void enable()
   {
-    uint8_t reg = readRegister(LTR390_MAIN_CTRL);
-    reg |= 0x02;
-    writeRegister(LTR390_MAIN_CTRL, reg);
+    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_MAIN_CTRL);
+    reg |= LTR390_MAIN_CTRL::ENABLE;
+    writeRegister(LTR390RT_REGISTER::LTR390_MAIN_CTRL, reg);
   }
 
   void disable()
   {
-    uint8_t reg = readRegister(LTR390_MAIN_CTRL);
-    reg &= ~0x02;
-    writeRegister(LTR390_MAIN_CTRL, reg);
+    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_MAIN_CTRL);
+    reg &= ~LTR390_MAIN_CTRL::ENABLE;
+    writeRegister(LTR390RT_REGISTER::LTR390_MAIN_CTRL, reg);
   }
 
-  bool isEnabled()
+  bool isEnabled() const
   {
-    uint8_t reg = readRegister(LTR390_MAIN_CTRL);
-    return (reg & 0x02) > 0;
+    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_MAIN_CTRL);
+    return (reg & LTR390_MAIN_CTRL::ENABLE) > 0;
   }
-
 
   //////////////////////////////////////////////
   //
   //  MEASUREMENT CONFIGURATION
   //
-  void setResolution(uint8_t resolution)  //  resolution = 0..5 (2 default)
+  void setResolution(uint8_t resolution) //  resolution = 0..5 (2 default)
   {
-    if (resolution > 5) resolution = 5;
+    if (resolution > 5)
+      resolution = 5;
     _resolution = resolution;
-    uint8_t reg = readRegister(LTR390_ALS_UVS_MEAS_RATE);
+    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_MEAS_RATE);
     reg &= 0x07;
     reg |= (resolution << 4);
-    writeRegister(LTR390_ALS_UVS_MEAS_RATE, reg);
+    writeRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_MEAS_RATE, reg);
   }
 
-  uint8_t getResolution()
+  uint8_t getResolution() const
   {
-    uint8_t reg = readRegister(LTR390_ALS_UVS_MEAS_RATE);
+    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_MEAS_RATE);
     return (reg >> 4) & 0x07;
   }
 
-  float getIntegrationTime()
+  float getIntegrationTime() const
   {
-    const uint16_t intTime[6] = { 800, 400, 200, 100, 50, 25 };
+    static constexpr uint16_t intTime[6] = {800, 400, 200, 100, 50, 25};
     return intTime[_resolution] * 0.5f;
   }
 
   //////////////////////////////////////////////
 
-  void setRate(uint8_t rate)  //  rate = 0..7 (2 default)
+  void setRate(uint8_t rate) //  rate = 0..7 (2 default)
   {
-    if (rate > 7) rate = 7;
+    if (rate > 7)
+      rate = 7;
     _rate = rate;
-    uint8_t reg = readRegister(LTR390_ALS_UVS_MEAS_RATE);
+    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_MEAS_RATE);
     reg &= 0xF8;
     reg |= rate;
-    writeRegister(LTR390_ALS_UVS_MEAS_RATE, reg);
+    writeRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_MEAS_RATE, reg);
   }
 
-  uint8_t getRate()
+  uint8_t getRate() const
   {
-    uint8_t reg = readRegister(LTR390_ALS_UVS_MEAS_RATE);
+    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_MEAS_RATE);
     return reg & 0x07;
   }
 
-  float getMeasurementTime()
+  float getMeasurementTime() const
   {
-    const uint16_t measTime[8] = { 25, 50, 100, 200, 500, 1000, 2000, 2000};
+    static constexpr uint16_t measTime[8] = {25, 50, 100, 200, 500, 1000, 2000, 2000};
     return measTime[_rate];
   }
 
   //////////////////////////////////////////////
 
-  void setGain(uint8_t gain)  //  gain = 0..4
+  void setGain(uint8_t gain) //  gain = 0..4
   {
-    if (gain > 4) gain = 4;
+    if (gain > 4)
+      gain = 4;
     _gain = gain;
-    uint8_t reg = readRegister(LTR390_ALS_UVS_GAIN);
+    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_GAIN);
     reg &= 0xF8;
     reg |= gain;
-    writeRegister(LTR390_ALS_UVS_GAIN, reg);
+    writeRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_GAIN, reg);
   }
 
-  uint8_t getGain()
+  uint8_t getGain() const
   {
     //  return _gain; // from cache
-    uint8_t reg = readRegister(LTR390_ALS_UVS_GAIN);
+    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_GAIN);
     return reg & 0x07;
   }
 
-  uint8_t getGainFactor()
+  uint8_t getGainFactor() const
   {
-    const uint8_t gainFactor[5] = { 1, 3, 6, 9, 18 };
+    static constexpr uint8_t gainFactor[5] = {1, 3, 6, 9, 18};
     return gainFactor[_gain];
   }
-
 
   //////////////////////////////////////////////
   //
   //  PART_ID
   //
-  uint8_t getPartID()
+  uint8_t getPartID() const
   {
-    uint8_t reg = readRegister(LTR390_PART_ID);
+    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_PART_ID);
     return reg >> 4;
   }
 
-  uint8_t getRevisionID()
+  uint8_t getRevisionID() const
   {
-    uint8_t reg = readRegister(LTR390_PART_ID);
+    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_PART_ID);
     return reg & 0x0F;
   }
-
 
   //////////////////////////////////////////////
   //
   //  MAIN STATUS
   //
-  uint8_t getStatus()
+  uint8_t getStatus() const
   {
-    uint8_t reg = readRegister(LTR390_MAIN_STATUS);
+    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_MAIN_STATUS);
     return reg & 0x38;
   }
 
-  bool getPowerOnStatus()
+  bool getPowerOnStatus() const
   {
-    uint8_t reg = readRegister(LTR390_MAIN_STATUS);
+    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_MAIN_STATUS);
     return (reg & 0x20) > 0;
   }
 
-  bool getInterruptStatus()
+  bool getInterruptStatus() const
   {
-    uint8_t reg = readRegister(LTR390_MAIN_STATUS);
+    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_MAIN_STATUS);
     return (reg & 0x10) > 0;
   }
 
-  bool getDataStatus()
+  bool getDataStatus() const
   {
-    uint8_t reg = readRegister(LTR390_MAIN_STATUS);
+    uint8_t reg = readRegister(LTR390RT_REGISTER::LTR390_MAIN_STATUS);
     return (reg & 0x08) > 0;
   }
-
 
   //////////////////////////////////////////////
   //
   //  GET DATA
   //
-  uint32_t getALSData()
+  uint32_t getALSData() const
   {
-    uint32_t value = readRegister(LTR390_ALS_DATA_2) & 0x0F;
+    uint32_t value = readRegister(LTR390RT_REGISTER::LTR390_ALS_DATA_2) & 0x0F;
     value <<= 8;
-    value += readRegister(LTR390_ALS_DATA_1);
+    value += readRegister(LTR390RT_REGISTER::LTR390_ALS_DATA_1);
     value <<= 8;
-    value += readRegister(LTR390_ALS_DATA_0);
+    value += readRegister(LTR390RT_REGISTER::LTR390_ALS_DATA_0);
     return value;
   }
 
-  uint32_t getUVSData()
+  uint32_t getUVSData() const
   {
-    uint32_t value = readRegister(LTR390_UVS_DATA_2) & 0x0F;
+    uint32_t value = readRegister(LTR390RT_REGISTER::LTR390_UVS_DATA_2) & 0x0F;
     value <<= 8;
-    value += readRegister(LTR390_UVS_DATA_1);
+    value += readRegister(LTR390RT_REGISTER::LTR390_UVS_DATA_1);
     value <<= 8;
-    value += readRegister(LTR390_UVS_DATA_0);
+    value += readRegister(LTR390RT_REGISTER::LTR390_UVS_DATA_0);
     return value;
   }
 
-  float getLUX(float windowsFactor = 1.0f)
+  float getLUX(float windowsFactor = 1.0f) const
   {
     float lux = (100 * 0.6f) * getALSData();
     lux /= (getGainFactor() * getIntegrationTime());
-    if (windowsFactor > 1.0f) lux *= windowsFactor;
+    if (windowsFactor > 1.0f)
+      lux *= windowsFactor;
     return lux;
   }
 
-  float getUVIndex(float windowsFactor = 1.0)
+  float getUVIndex(float windowsFactor = 1.0) const
   {
     float reciprokeSensitivity = (18 * 400) / 2300.0f;
     reciprokeSensitivity /= (getGainFactor() * getIntegrationTime());
     uint32_t uvi = getUVSData() * reciprokeSensitivity;
-    if (windowsFactor > 1.0) uvi *= windowsFactor;
+    if (windowsFactor > 1.0)
+      uvi *= windowsFactor;
     return uvi;
   }
 
@@ -285,24 +302,23 @@ public:
   //
   int setInterruptConfig(uint8_t value)
   {
-    return writeRegister(LTR390_INT_CFG, value);
+    return writeRegister(LTR390RT_REGISTER::LTR390_INT_CFG, value);
   }
 
   uint8_t getInterruptConfig()
   {
-    return readRegister(LTR390_INT_CFG);
+    return readRegister(LTR390RT_REGISTER::LTR390_INT_CFG);
   }
 
   int setInterruptPersist(uint8_t value)
   {
-    return writeRegister(LTR390_INT_PST, value);
+    return writeRegister(LTR390RT_REGISTER::LTR390_INT_PST, value);
   }
 
   uint8_t getInterruptPersist()
   {
-    return readRegister(LTR390_INT_PST);
+    return readRegister(LTR390RT_REGISTER::LTR390_INT_PST);
   }
-
 
   //////////////////////////////////////////////
   //
@@ -311,98 +327,89 @@ public:
   //
   void setHighThreshold(uint32_t value)
   {
-    writeRegister(LTR390_ALS_UVS_THRES_UP_0, value & 0xFF);
+    writeRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_UP_0, value & 0xFF);
     value >>= 8;
-    writeRegister(LTR390_ALS_UVS_THRES_UP_1, value & 0xFF);
+    writeRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_UP_1, value & 0xFF);
     value >>= 8;
-    writeRegister(LTR390_ALS_UVS_THRES_UP_2, value & 0x0F);
+    writeRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_UP_2, value & 0x0F);
   }
 
-
-  uint32_t getHighThreshold()
+  uint32_t getHighThreshold() const
   {
-    uint32_t value = readRegister(LTR390_ALS_UVS_THRES_UP_2) & 0x0F;
+    uint32_t value = readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_UP_2) & 0x0F;
     value <<= 8;
-    value += readRegister(LTR390_ALS_UVS_THRES_UP_1);
+    value += readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_UP_1);
     value <<= 8;
-    value += readRegister(LTR390_ALS_UVS_THRES_UP_0);
+    value += readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_UP_0);
     return value;
   }
-
 
   void setLowThreshold(uint32_t value)
   {
-    writeRegister(LTR390_ALS_UVS_THRES_LOW_0, value & 0xFF);
+    writeRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_LOW_0, value & 0xFF);
     value >>= 8;
-    writeRegister(LTR390_ALS_UVS_THRES_LOW_1, value & 0xFF);
+    writeRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_LOW_1, value & 0xFF);
     value >>= 8;
-    writeRegister(LTR390_ALS_UVS_THRES_LOW_2, value & 0x0F);
+    writeRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_LOW_2, value & 0x0F);
   }
 
-
-  uint32_t getLowThreshold()
+  uint32_t getLowThreshold() const
   {
-    uint32_t value = readRegister(LTR390_ALS_UVS_THRES_LOW_2) & 0x0F;
+    uint32_t value = readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_LOW_2) & 0x0F;
     value <<= 8;
-    value += readRegister(LTR390_ALS_UVS_THRES_LOW_1);
+    value += readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_LOW_1);
     value <<= 8;
-    value += readRegister(LTR390_ALS_UVS_THRES_LOW_0);
+    value += readRegister(LTR390RT_REGISTER::LTR390_ALS_UVS_THRES_LOW_0);
     return value;
   }
 
-
-//////////////////////////////////////////////
-//
-//  PRIVATE
-//
+  //////////////////////////////////////////////
+  //
+  //  PRIVATE
+  //
   int writeRegister(uint8_t reg, uint8_t value)
   {
     _wire->beginTransmission(_address);
     _wire->write(reg);
     _wire->write(value);
     int n = _wire->endTransmission();
-    //if (n != 0)
+    // if (n != 0)
     //{
-    //  Serial.print("write:\t");
-    //  Serial.println(n);
-    //}
+    //   Serial.print("write:\t");
+    //   Serial.println(n);
+    // }
     return n;
   }
 
-
-  uint8_t readRegister(uint8_t reg)
+  uint8_t readRegister(uint8_t reg) const
   {
     _wire->beginTransmission(_address);
     _wire->write(reg);
     int n = _wire->endTransmission();
-    //if (n != 0)
+    // if (n != 0)
     //{
-    //  Serial.print("read:\t");
-    //  Serial.println(n);
-    //  return n;
-    //}
+    //   Serial.print("read:\t");
+    //   Serial.println(n);
+    //   return n;
+    // }
 
     n = _wire->requestFrom(_address, (uint8_t)1);
     if (n != 1)
     {
-    //  Serial.print("requestFrom: \t");
-    //  Serial.print(n);
-    //  return n;
+      //  Serial.print("requestFrom: \t");
+      //  Serial.print(n);
+      //  return n;
     }
     return _wire->read();
   }
 
-
 private:
-  TwoWire * _wire;
-  uint8_t  _address;
+  TwoWire *_wire;
+  uint8_t _address;
 
-  uint8_t  _resolution;
-  uint8_t  _rate;
-  uint8_t  _gain;
-
+  uint8_t _resolution;
+  uint8_t _rate;
+  uint8_t _gain;
 };
 
-
 //  -- END OF FILE --
-

--- a/LTR390.h
+++ b/LTR390.h
@@ -302,7 +302,7 @@ public:
     return writeRegister(LTR390RT_REGISTER::LTR390_INT_CFG, value);
   }
 
-  uint8_t getInterruptConfig()
+  uint8_t getInterruptConfig() const
   {
     return readRegister(LTR390RT_REGISTER::LTR390_INT_CFG);
   }
@@ -312,7 +312,7 @@ public:
     return writeRegister(LTR390RT_REGISTER::LTR390_INT_PST, value);
   }
 
-  uint8_t getInterruptPersist()
+  uint8_t getInterruptPersist() const
   {
     return readRegister(LTR390RT_REGISTER::LTR390_INT_PST);
   }

--- a/LTR390.h
+++ b/LTR390.h
@@ -397,7 +397,7 @@ public:
     return n;
   }
 
-  uint8_t readRegister(uint8_t reg)
+  uint8_t readRegister(uint8_t reg) const
   {
     _wire->beginTransmission(_address);
     _wire->write(reg);

--- a/library.json
+++ b/library.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "https://github.com/RobTillaart/LTR390.git"
   },
-  "version": "0.1.4",
+  "version": "0.2.0",
   "license": "MIT",
   "frameworks": "*",
   "platforms": "*",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=LTR390_RT
-version=0.1.4
+version=0.2.0
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Arduino library for the I2C LTR390 UV sensor.


### PR DESCRIPTION
This sync the version to 0.2.0 with the 390DFR @RobTillaart 

## [0.2.0] - 2026-04-08

### Added
- add `[[nodiscard]]` to critical getters to enforce return value usage.

### Changed
- refactor register definitions using namespaces and `constexpr`.
- introduce `LTR390RT` root namespace for all register and bitfield definitions.
- remove internal cached state (`_gain`, `_rate`, `_resolution`) and rely on register reads.
- improve readability and maintainability by replacing magic numbers with named constants.
- explicit float literals to avoid implicit conversions.

### Fixed
- fix incorrect bit masking in `setRate()` that could overwrite resolution bits.
- fix incorrect bit mask handling in `setGain()`.
- fix type error in `getUVIndex()` causing precision loss.

### Breaking Changes
- remove internal cached state. All configuration getters now read directly from hardware registers.
- register and constant definitions are now under the `LTR390RT` namespace.
